### PR TITLE
Updated Nginx Docker Image to alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM nginx:latest
+FROM nginx:1.11-alpine
 
-WORKDIR /root/
-
-RUN apt-get update && apt-get install -y -q --no-install-recommends curl unzip && apt-get clean
-
-# download release of ecs-gen
 ENV ECS_GEN_RELEASE 0.3.1
-RUN curl -OL https://github.com/codesuki/ecs-gen/releases/download/$ECS_GEN_RELEASE/ecs-gen-linux-amd64.zip && unzip ecs-gen-linux-amd64.zip && cp ecs-gen-linux-amd64 /usr/local/bin/ecs-gen
+
+RUN apk add --update bash openssl && \
+    rm -rf /var/cache/apk/*
+
+RUN wget -q https://github.com/codesuki/ecs-gen/releases/download/$ECS_GEN_RELEASE/ecs-gen-linux-amd64.zip && \
+    unzip ecs-gen-linux-amd64.zip && \
+    cp ecs-gen-linux-amd64 /usr/local/bin/ecs-gen && \
+    rm -rf ecs-gen-linux-amd64*
 
 COPY nginx.tmpl nginx.tmpl
 
-CMD nginx && ecs-gen --signal="nginx -s reload" --template=nginx.tmpl --output=/etc/nginx/conf.d/default.conf
+CMD ["nginx", "-g", "daemon off;"] && ecs-gen --signal="nginx -s reload" --template=nginx.tmpl --output=/etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.11-alpine
 
 ENV ECS_GEN_RELEASE 0.3.1
 
-RUN apk add --update bash openssl && \
+RUN apk add --update bash ca-certificates openssl && \
     rm -rf /var/cache/apk/*
 
 RUN wget -q https://github.com/codesuki/ecs-gen/releases/download/$ECS_GEN_RELEASE/ecs-gen-linux-amd64.zip && \


### PR DESCRIPTION
This PR updates is to add Nginx alpine docker image instead of Nginx jessie image. This will reduce the docker image size to half.