### PR TITLE
Use 'name' for upstream

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -39,19 +39,19 @@ server {
         }
 }
 
-
-{{ range $domain, $container := . }}
-upstream {{ $domain }} {
+{{ range $name, $container := . }}
+upstream {{ $name }} {
     {{ range $_, $value := $container }}
          server {{ $value.Address }}:{{ $value.Port }};
     {{ end }}
 }
 server {
-        server_name {{ $domain }};
+        server_name {{ (index $container 0).Host }};
         listen 80;
         access_log /var/log/nginx/access.log vhost;
         location / {
-                proxy_pass http://{{ $domain }};
+                proxy_pass http://{{ $name }};
         }
 }
 {{ end }}
+


### PR DESCRIPTION
As mentioned in the [other PR](https://github.com/codesuki/ecs-gen/pull/18), the motivation for this is to allow for multiple domain names/regex matching within the server_name field, without breaking the nginx.conf syntax.

This PR could actually be merged separately from the ecs-gen one, but it really only makes sense if given the extra values. (Merging this one before the other should not break existing templates, since the values being inserted should be the same).